### PR TITLE
Make IOCs modular; don't scan for empty lines

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,3 +8,10 @@ max_concurrency: 5
 max_retries: 3
 start_time: "2025-03-14T00:00:00Z"
 end_time: "2025-03-16T00:00:00Z"
+ioc:
+  name: "tj-actions/changed-files"
+# custom example
+# ioc:
+#  name: "custom-ioc-name"
+#  digest: "0e58ed8671d6b60d0890c21b07f8835ace038e67"
+#  pattern: "(?:^|\\s+)([A-Za-z0-9+/]{40,}={0,3})"

--- a/pkg/ioc/ioc.go
+++ b/pkg/ioc/ioc.go
@@ -1,0 +1,87 @@
+package ioc
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type Config struct {
+	Name    string
+	Digest  string
+	Pattern string
+}
+
+type IOC struct {
+	name   string
+	digest string
+	regex  *regexp.Regexp
+}
+
+var existingIOC = map[string]struct {
+	digest  string
+	pattern string
+}{
+	"tj-actions/changed-files": {
+		digest:  "0e58ed8671d6b60d0890c21b07f8835ace038e67",
+		pattern: `(?:^|\s+)([A-Za-z0-9+/]{40,}={0,3})`,
+	},
+}
+
+func GetPredefinedIOC(name string) (*IOC, bool) {
+	predefined, exists := existingIOC[name]
+	if !exists {
+		return nil, false
+	}
+
+	regex, err := regexp.Compile(predefined.pattern)
+	if err != nil {
+		return nil, false
+	}
+
+	return &IOC{
+		name:   name,
+		digest: predefined.digest,
+		regex:  regex,
+	}, true
+}
+
+func NewIOC(config *Config) (*IOC, error) {
+	if config.Name != "" && config.Digest == "" && config.Pattern == "" {
+		if ioc, exists := GetPredefinedIOC(config.Name); exists {
+			return ioc, nil
+		}
+		return nil, fmt.Errorf("predefined IOC not found: %s", config.Name)
+	}
+
+	if config.Pattern == "" {
+		return nil, fmt.Errorf("pattern is required for novel IOC")
+	}
+
+	regex, err := regexp.Compile(config.Pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex pattern: %w", err)
+	}
+
+	name := config.Name
+	if name == "" {
+		name = "custom"
+	}
+
+	return &IOC{
+		name:   name,
+		digest: config.Digest,
+		regex:  regex,
+	}, nil
+}
+
+func (i *IOC) GetName() string {
+	return i.name
+}
+
+func (i *IOC) GetDigest() string {
+	return i.digest
+}
+
+func (i *IOC) GetRegex() *regexp.Regexp {
+	return i.regex
+}

--- a/pkg/tj-scan/tj-scan.go
+++ b/pkg/tj-scan/tj-scan.go
@@ -3,6 +3,7 @@ package tjscan
 import (
 	"time"
 
+	"github.com/chainguard-dev/tj-scan/pkg/ioc"
 	"github.com/google/go-github/v69/github"
 )
 
@@ -14,6 +15,7 @@ type Request struct {
 	CachedResults map[string]bool
 	Client        *github.Client
 	EndTime       time.Time
+	IOC           *ioc.IOC
 	Owner         string
 	RepoName      string
 	StartTime     time.Time


### PR DESCRIPTION
This PR makes scanning for IOCs more modular. Documented cases exist in a map and new digests/regex patterns can be defined in `config.yaml` or when invoking the command via CLI.