### PR TITLE
Improve log parsing, clean up nested code

### DIFF
--- a/cmd/tj-scan/main.go
+++ b/cmd/tj-scan/main.go
@@ -43,7 +43,7 @@ func main() {
 	startTimeFlag := flag.String("start", viper.GetString("start_time"), "Start time for workflow run filtering (RFC3339)")
 	endTimeFlag := flag.String("end", viper.GetString("end_time"), "End time for workflow run filtering (RFC3339)")
 	iocNameFlag := flag.String("ioc-name", viper.GetString("ioc.name"), "IOC Logs to scan for (e.g. tj-actions/changed-files")
-	iocDigestFlag := flag.String("ioc-digest", viper.GetString("ioc.digest"), "Malicious digest to search for in logs")
+	iocContentFlag := flag.String("ioc-content", viper.GetString("ioc.content"), "Comma-separated string(s) to search for in logs")
 	iocPatternFlag := flag.String("ioc-pattern", viper.GetString("ioc.pattern"), "Regex pattern to search logs with")
 	flag.Parse()
 
@@ -54,9 +54,23 @@ func main() {
 		logger.Fatal("GITHUB_TOKEN or -token must be provided")
 	}
 
+	contentParts := make([]string, 0)
+	if *iocContentFlag != "" {
+		for part := range strings.SplitSeq(*iocContentFlag, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				contentParts = append(contentParts, trimmed)
+			}
+		}
+
+		if len(contentParts) == 0 {
+			logger.Warn("ioc-content flag was provided but no valid content was parsed")
+		}
+	}
+
 	ic := &ioc.Config{
 		Name:    *iocNameFlag,
-		Digest:  *iocDigestFlag,
+		Content: contentParts,
 		Pattern: *iocPatternFlag,
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -13,5 +13,5 @@ ioc:
 # custom example
 # ioc:
 #  name: "custom-ioc-name"
-#  digest: "0e58ed8671d6b60d0890c21b07f8835ace038e67"
+#  content: "0e58ed8671d6b60d0890c21b07f8835ace038e67,example-string,example-string2"
 #  pattern: "(?:^|\\s+)([A-Za-z0-9+/]{40,}={0,3})"

--- a/pkg/file/output.go
+++ b/pkg/file/output.go
@@ -40,11 +40,15 @@ func writeCSV(filename string, results []tjscan.Result) error {
 		"WorkflowRunURL",
 		"Base64Data",
 		"DecodedData",
+		"LineData",
 	}); err != nil {
 		return err
 	}
 
 	for _, res := range results {
+		if res.IsEmpty() {
+			continue
+		}
 		record := []string{
 			res.Repository,
 			res.WorkflowFileName,
@@ -52,7 +56,7 @@ func writeCSV(filename string, results []tjscan.Result) error {
 			res.WorkflowRunURL,
 			res.Base64Data,
 			res.DecodedData,
-			res.EmptyLines,
+			res.LineData,
 		}
 		if err := writer.Write(record); err != nil {
 			return err

--- a/pkg/ioc/ioc.go
+++ b/pkg/ioc/ioc.go
@@ -7,22 +7,22 @@ import (
 
 type Config struct {
 	Name    string
-	Digest  string
+	Content []string
 	Pattern string
 }
 
 type IOC struct {
-	name   string
-	digest string
-	regex  *regexp.Regexp
+	name    string
+	content []string
+	regex   *regexp.Regexp
 }
 
 var existingIOC = map[string]struct {
-	digest  string
+	content []string
 	pattern string
 }{
 	"tj-actions/changed-files": {
-		digest:  "0e58ed8671d6b60d0890c21b07f8835ace038e67",
+		content: []string{"SHA:0e58ed8671d6b60d0890c21b07f8835ace038e67"},
 		pattern: `(?:^|\s+)([A-Za-z0-9+/]{40,}={0,3})`,
 	},
 }
@@ -39,14 +39,14 @@ func GetPredefinedIOC(name string) (*IOC, bool) {
 	}
 
 	return &IOC{
-		name:   name,
-		digest: predefined.digest,
-		regex:  regex,
+		name:    name,
+		content: predefined.content,
+		regex:   regex,
 	}, true
 }
 
 func NewIOC(config *Config) (*IOC, error) {
-	if config.Name != "" && config.Digest == "" && config.Pattern == "" {
+	if config.Name != "" && len(config.Content) == 0 && config.Pattern == "" {
 		if ioc, exists := GetPredefinedIOC(config.Name); exists {
 			return ioc, nil
 		}
@@ -68,9 +68,9 @@ func NewIOC(config *Config) (*IOC, error) {
 	}
 
 	return &IOC{
-		name:   name,
-		digest: config.Digest,
-		regex:  regex,
+		name:    name,
+		content: config.Content,
+		regex:   regex,
 	}, nil
 }
 
@@ -78,8 +78,8 @@ func (i *IOC) GetName() string {
 	return i.name
 }
 
-func (i *IOC) GetDigest() string {
-	return i.digest
+func (i *IOC) GetContent() []string {
+	return i.content
 }
 
 func (i *IOC) GetRegex() *regexp.Regexp {

--- a/pkg/tj-scan/tj-scan.go
+++ b/pkg/tj-scan/tj-scan.go
@@ -25,15 +25,19 @@ type Request struct {
 }
 
 type Result struct {
-	Repository       string `json:"repository"`
-	WorkflowFileName string `json:"workflow_file_name"`
-	WorkflowURL      string `json:"workflow_url"`
-	WorkflowRunURL   string `json:"workflow_run_url"`
-	Base64Data       string `json:"base64_data"`
-	DecodedData      string `json:"decoded_data"`
-	EmptyLines       string `json:"empty_lines"`
+	Base64Data       string `json:"base64_data,omitempty"`
+	DecodedData      string `json:"decoded_data,omitempty"`
+	LineData         string `json:"line_data,omitempty"`
+	Repository       string `json:"repository,omitempty"`
+	WorkflowFileName string `json:"workflow_file_name,omitempty"`
+	WorkflowRunURL   string `json:"workflow_run_url,omitempty"`
+	WorkflowURL      string `json:"workflow_url,omitempty"`
+}
+
+func (r *Result) IsEmpty() bool {
+	return r.Base64Data == "" && r.DecodedData == "" && r.LineData == ""
 }
 
 type Cache struct {
-	Results []Result `json:"results"`
+	Results []Result `json:"results,omitempty"`
 }


### PR DESCRIPTION
This PR improves IOC configuration and scans logs for multiple strings.

Additionally, empty fields are omitted from rendered JSON and the code attempts to merge multiple results for the same run ID (e.g., base64/decoded findings and line data are merged into a single result instead of multiple).