### PR TITLE
Improve readability re: nesting; improve README; small regex fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ permissions:
       Path to final CSV output file
 -end string
       End time for workflow run filtering (RFC3339) (default "2025-03-16T00:00:00Z")
+-ioc-content string
+      Comma-separated string(s) to search for in logs
+-ioc-name string
+      IOC Logs to scan for (e.g. tj-actions/changed-files (default "tj-actions/changed-files")
+-ioc-pattern string
+      Regex pattern to search logs with
 -json string
       Path to final JSON output file
 -start string
@@ -61,5 +67,17 @@ $ chainctl auth octo-sts --scope chainguard-dev/tj-scan --identity ephemerality 
 2025/03/18 11:27:59 INFO Found 1 repositories to scan
 2025/03/18 11:27:59 INFO No existing cache found at cache.json, starting fresh
 ```
+
+Custom IOC configuration can be provided with the flags documented above or added to `config.yaml`:
+```yaml
+ioc:
+  name: "custom-ioc-name"
+  content: "0e58ed8671d6b60d0890c21b07f8835ace038e67,example-string,example-string2"
+  pattern: "(?:^|\\s+)([A-Za-z0-9+/]{40,}={0,3})"
+```
+
+`name` is a reference to the IOC
+`content` is the string or strings to search for in the Workflow logs
+`pattern` is an optional regex pattern to search for in the Workflow logs
 
 Results will be saved in the `results/` directory.

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	github.com/sagikazarmark/locafero v0.8.0 // indirect
+	github.com/sagikazarmark/locafero v0.9.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
-github.com/sagikazarmark/locafero v0.8.0 h1:mXaMVw7IqxNBxfv3LdWt9MDmcWDQ1fagDH918lOdVaQ=
-github.com/sagikazarmark/locafero v0.8.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
+github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
+github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=

--- a/pkg/ioc/ioc.go
+++ b/pkg/ioc/ioc.go
@@ -53,13 +53,17 @@ func NewIOC(config *Config) (*IOC, error) {
 		return nil, fmt.Errorf("predefined IOC not found: %s", config.Name)
 	}
 
-	if config.Pattern == "" {
-		return nil, fmt.Errorf("pattern is required for novel IOC")
+	if config.Pattern == "" && len(config.Content) == 0 {
+		return nil, fmt.Errorf("either content or pattern is required for novel IOC")
 	}
 
-	regex, err := regexp.Compile(config.Pattern)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regex pattern: %w", err)
+	var regex *regexp.Regexp
+	var err error
+	if config.Pattern != "" {
+		regex, err = regexp.Compile(config.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex pattern: %w", err)
+		}
 	}
 
 	name := config.Name

--- a/pkg/request/retry.go
+++ b/pkg/request/retry.go
@@ -15,7 +15,7 @@ func WithRetry(ctx context.Context, logger *clog.Logger, operation func() error)
 	maxRetries := viper.GetInt("max_retries")
 	attempt := 0
 
-	wrappedOperation := func() (interface{}, error) {
+	wrappedOperation := func() (any, error) {
 		if ctx.Err() != nil {
 			return nil, backoff.Permanent(ctx.Err())
 		}


### PR DESCRIPTION
This PR cleans up the heavy nesting in `logs.go` and allows either content or pattern to be specified when searching logs, rather than requiring both.

The README has also been updated to reflect the new configuration options.