### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:
@@ -18,6 +20,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
     groups:
       all:
         update-types:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches: ["main"]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yaml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yaml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
Automated GitHub Actions security hardening (zizmor + actionlint + shellcheck,
plus manual review). Workflow-config only — no application code is touched.

## Changes

- **Scope down checkout credentials** — `persist-credentials: false` on the
  build checkout. The job (setup-go, golangci-lint, make) does no downstream
  git writes, so leaving the checkout token in `.git/config` is unnecessary
  exposure.

- **Replace workflow-level `read-all` with least privilege** — the blanket
  `read-all` permission becomes `permissions: {}` at the workflow level, with
  the specific scopes granted on the job that needs them (the SARIF upload path
  is preserved).

- **Add a zizmor config + dependabot cooldown** — a `.github/zizmor.yml`
  disabling a few cosmetic pedantic rules, plus a 3-day cooldown on each
  dependabot ecosystem so brand-new (and potentially compromised) dependency
  releases aren't pulled the instant they ship.

Refs: PSEC-923